### PR TITLE
ci: add casperfpga integration testing on Python 3.10-3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,35 @@ jobs:
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  test-with-casperfpga:
+    # Python 3.12 blocked: katcp 0.9.3 requires tornado<5 which
+    # uses backports.ssl_match_hostname (removed in 3.12)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies with casperfpga
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[dev,hardware]
+      - name: Verify casperfpga imports
+        run: |
+          python -c "
+          import casperfpga
+          from casperfpga.transport_tapcp import TapcpTransport
+          from casperfpga import i2c, i2c_gpio, i2c_volt, i2c_eeprom
+          from casperfpga import i2c_sn, i2c_bar, i2c_motion, i2c_temp
+          from casperfpga import snapadc
+          print('All casperfpga imports OK')
+          "
+      - name: Test with pytest
+        run: |
+          pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
 plot = [
   "matplotlib",
 ]
+hardware = [
+  "casperfpga @ git+https://github.com/EIGSEP/casperfpga.git@py312",
+]
 dev = [
   "build",
   "matplotlib",


### PR DESCRIPTION
## Summary

- Adds a `hardware` optional dependency group (`pip install .[hardware]`) that installs casperfpga from the EIGSEP fork's `py312` branch
- Adds a `test-with-casperfpga` CI job that installs casperfpga on Python 3.10/3.11, verifies all imports used by eigsep_corr, and runs the full test suite
- Previously, casperfpga was never installed or tested in CI — Python version bumps could silently break the hardware integration path

The `py312` branch on EIGSEP/casperfpga cherry-picks fixes from upstream:
1. `collections.abc` fix — `collections.Callable`/`Iterable` removed in Python 3.10+
2. `importlib.resources` fix — `pkg_resources.resource_filename` deprecated in 3.12
3. progska C extension removal — eliminates the main compilation blocker for modern Python
4. `katcp>=0.9.3` — fixes `collections.Mapping` in katcp itself

## Python 3.12 blocker

`katcp==0.9.3` (latest) requires `tornado<5`, and tornado 4.x uses `backports.ssl_match_hostname` which was removed in Python 3.12. The casperfpga integration job runs on 3.10/3.11 only until katcp gets a tornado 5+ compatible release.

## Follow-up

A separate PR will rebase onto upstream `py312-noprogska` for full alignment with upstream, which requires adapting the `SnapAdc.__init__` signature change in `fpga.py` and `testing.py`.

## Test plan

- [x] Verify `test` job still passes on 3.10-3.12 (no casperfpga, existing behavior)
- [x] Verify `test-with-casperfpga` job passes on 3.10, 3.11
- [x] Verify `pip install .[hardware]` works locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)